### PR TITLE
Supports parsing .target(name:) syntax

### DIFF
--- a/Sources/Library/Parsing/PackageSwiftFileParserLive/Internal/IntermediatePackageSwiftFile+Target+Dependency.swift
+++ b/Sources/Library/Parsing/PackageSwiftFileParserLive/Internal/IntermediatePackageSwiftFile+Target+Dependency.swift
@@ -2,6 +2,7 @@ extension IntermediatePackageSwiftFile.Target {
     enum Dependency: Decodable {
         private enum CodingKeys: CodingKey {
             case byName
+            case target
             case product
         }
 
@@ -20,7 +21,9 @@ extension IntermediatePackageSwiftFile.Target {
         init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             if container.allKeys.contains(CodingKeys.byName) {
-                self = try .decodeByName(using: container)
+                self = try .decodeName(using: container, forKey: .byName)
+            } else if container.allKeys.contains(CodingKeys.target) {
+                self = try .decodeName(using: container, forKey: .target)
             } else if container.allKeys.contains(CodingKeys.product) {
                 self = try .decodeProduct(using: container)
             } else {
@@ -33,8 +36,8 @@ extension IntermediatePackageSwiftFile.Target {
 }
 
 private extension IntermediatePackageSwiftFile.Target.Dependency {
-    private static func decodeByName(using container: KeyedDecodingContainer<Self.CodingKeys>) throws -> Self {
-        let values = try container.decode([ByNameComponent].self, forKey: .byName)
+    private static func decodeName(using container: KeyedDecodingContainer<Self.CodingKeys>, forKey key: CodingKeys) throws -> Self {
+        let values = try container.decode([NameComponent].self, forKey: key)
         guard values.count >= 1 else {
             let debugDescription = "Expected to decode at least 1 string but found \(values.count)"
             throw DecodingError.dataCorrupted(.init(codingPath: container.codingPath, debugDescription: debugDescription))
@@ -67,7 +70,7 @@ private extension IntermediatePackageSwiftFile.Target.Dependency {
 }
 
 extension IntermediatePackageSwiftFile.Target.Dependency {
-    private enum ByNameComponent: Decodable {
+    private enum NameComponent: Decodable {
         struct PlatformNamesContainer: Decodable {
             let platformNames: [String]
         }

--- a/Tests/PackageSwiftFileParserLiveTests/Mock/DumpPackageServiceMock.swift
+++ b/Tests/PackageSwiftFileParserLiveTests/Mock/DumpPackageServiceMock.swift
@@ -3,10 +3,11 @@ import Foundation
 
 struct DumpPackageServiceMock: DumpPackageService {
     private let fileURLMap: [URL: URL] = [
-        URL.Mock.examplePackageA: Bundle.module.url(forMockDumpPackageNamed: "example-package-a"),
-        URL.Mock.examplePackageB: Bundle.module.url(forMockDumpPackageNamed: "example-package-b"),
-        URL.Mock.examplePackageC: Bundle.module.url(forMockDumpPackageNamed: "example-package-c"),
-        URL.Mock.examplePackageD: Bundle.module.url(forMockDumpPackageNamed: "example-package-d")
+        URL.Mock.Example.packageA: Bundle.module.url(forMockDataNamed: "example-package-a"),
+        URL.Mock.Example.packageB: Bundle.module.url(forMockDataNamed: "example-package-b"),
+        URL.Mock.Example.packageC: Bundle.module.url(forMockDataNamed: "example-package-c"),
+        URL.Mock.DependencySyntax.byNameWithPlatformNames: Bundle.module.url(forMockDataNamed: "dependency-syntax-byname-with-platform-names"),
+        URL.Mock.DependencySyntax.target: Bundle.module.url(forMockDataNamed: "dependency-syntax-target")
     ]
 
     func dumpPackageForSwiftPackageFile(at fileURL: URL) throws -> Data {
@@ -16,7 +17,7 @@ struct DumpPackageServiceMock: DumpPackageService {
 }
 
 private extension Bundle {
-    func url(forMockDumpPackageNamed filename: String) -> URL {
+    func url(forMockDataNamed filename: String) -> URL {
         return url(forResource: "MockData/" + filename, withExtension: "json")!
     }
 }

--- a/Tests/PackageSwiftFileParserLiveTests/Mock/URL+Mock.swift
+++ b/Tests/PackageSwiftFileParserLiveTests/Mock/URL+Mock.swift
@@ -2,20 +2,28 @@ import Foundation
 
 extension URL {
     enum Mock {
-        static var examplePackageA: URL {
-            return NSURL.fileURL(withPath: "/Users/simon/Developer/Example/ExamplePackageA/Package.swift")
+        enum Example {
+            static var packageA: URL {
+                return NSURL.fileURL(withPath: "/Users/simon/Developer/Example/PackageA/Package.swift")
+            }
+            
+            static var packageB: URL {
+                return NSURL.fileURL(withPath: "/Users/simon/Developer/Example/PackageB/Package.swift")
+            }
+            
+            static var packageC: URL {
+                return NSURL.fileURL(withPath: "/Users/simon/Developer/Example/PackageC/Package.swift")
+            }
         }
 
-        static var examplePackageB: URL {
-            return NSURL.fileURL(withPath: "/Users/simon/Developer/Example/ExamplePackageB/Package.swift")
-        }
+        enum DependencySyntax {
+            static var byNameWithPlatformNames: URL {
+                return NSURL.fileURL(withPath: "/Users/simon/Developer/DependencySyntax/ByNamePlatformNames/Package.swift")
+            }
 
-        static var examplePackageC: URL {
-            return NSURL.fileURL(withPath: "/Users/simon/Developer/Example/ExamplePackageC/Package.swift")
-        }
-
-        static var examplePackageD: URL {
-            return NSURL.fileURL(withPath: "/Users/simon/Developer/Example/ExamplePackageD/Package.swift")
+            static var target: URL {
+                return NSURL.fileURL(withPath: "/Users/simon/Developer/DependencySyntax/Target/Package.swift")
+            }
         }
     }
 }

--- a/Tests/PackageSwiftFileParserLiveTests/Mock/URL+Mock.swift
+++ b/Tests/PackageSwiftFileParserLiveTests/Mock/URL+Mock.swift
@@ -6,11 +6,11 @@ extension URL {
             static var packageA: URL {
                 return NSURL.fileURL(withPath: "/Users/simon/Developer/Example/PackageA/Package.swift")
             }
-            
+
             static var packageB: URL {
                 return NSURL.fileURL(withPath: "/Users/simon/Developer/Example/PackageB/Package.swift")
             }
-            
+
             static var packageC: URL {
                 return NSURL.fileURL(withPath: "/Users/simon/Developer/Example/PackageC/Package.swift")
             }

--- a/Tests/PackageSwiftFileParserLiveTests/MockData/dependency-syntax-byname-with-platform-names.json
+++ b/Tests/PackageSwiftFileParserLiveTests/MockData/dependency-syntax-byname-with-platform-names.json
@@ -10,33 +10,12 @@
           "productFilter" : null
         }
       ]
-    },
-    {
-      "sourceControl" : [
-        {
-          "identity" : "keyboardtoolbar",
-          "location" : {
-            "remote" : [
-              "git@github.com:simonbs/KeyboardToolbar.git"
-            ]
-          },
-          "productFilter" : null,
-          "requirement" : {
-            "range" : [
-              {
-                "lowerBound" : "0.1.1",
-                "upperBound" : "1.0.0"
-              }
-            ]
-          }
-        }
-      ]
     }
   ],
-  "name" : "ExamplePackageB",
+  "name" : "DependencySyntaxByNameWithPlatformNames",
   "packageKind" : {
     "root" : [
-      "/Users/simon/Developer/Example/PackageB"
+      "/Users/simon/Developer/DependencySyntax/ByNameWithPlatformNames"
     ]
   },
   "pkgConfig" : null,
@@ -51,12 +30,12 @@
   ],
   "products" : [
     {
-      "name" : "ExampleLibraryB",
+      "name" : "ExampleLibraryD",
       "settings" : [
 
       ],
       "targets" : [
-        "ExampleLibraryB"
+        "ExampleLibraryD"
       ],
       "type" : {
         "library" : [
@@ -71,26 +50,20 @@
     {
       "dependencies" : [
         {
-          "product" : [
+          "byName" : [
             "ExampleLibraryC",
-            "ExamplePackageC",
-            null,
-            null
-          ]
-        },
-        {
-          "product" : [
-            "KeyboardToolbar",
-            "KeyboardToolbar",
-            null,
-            null
+            {
+              "platformNames": [
+                "ios"
+              ]
+            }
           ]
         }
       ],
       "exclude" : [
 
       ],
-      "name" : "ExampleLibraryB",
+      "name" : "ExampleLibraryD",
       "resources" : [
 
       ],

--- a/Tests/PackageSwiftFileParserLiveTests/MockData/dependency-syntax-target.json
+++ b/Tests/PackageSwiftFileParserLiveTests/MockData/dependency-syntax-target.json
@@ -6,16 +6,16 @@
       "fileSystem" : [
         {
           "identity" : "examplepackagec",
-          "path" : "/Users/simon/Developer/Example/ExamplePackageC",
+          "path" : "/Users/simon/Developer/Example/PackageC",
           "productFilter" : null
         }
       ]
     }
   ],
-  "name" : "ExamplePackageD",
+  "name" : "DependencySyntaxTarget",
   "packageKind" : {
     "root" : [
-      "/Users/simon/Developer/Example/ExamplePackageD"
+      "/Users/simon/Developer/DependencySyntax/Target"
     ]
   },
   "pkgConfig" : null,
@@ -50,13 +50,9 @@
     {
       "dependencies" : [
         {
-          "byName" : [
+          "target" : [
             "ExampleLibraryC",
-            {
-              "platformNames": [
-                "ios"
-              ]
-            }
+            null
           ]
         }
       ],

--- a/Tests/PackageSwiftFileParserLiveTests/MockData/example-package-a.json
+++ b/Tests/PackageSwiftFileParserLiveTests/MockData/example-package-a.json
@@ -7,7 +7,7 @@
   "name" : "ExamplePackageA",
   "packageKind" : {
     "root" : [
-      "/Users/simon/Developer/Example/ExamplePackageA"
+      "/Users/simon/Developer/Example/PackageA"
     ]
   },
   "pkgConfig" : null,

--- a/Tests/PackageSwiftFileParserLiveTests/MockData/example-package-c.json
+++ b/Tests/PackageSwiftFileParserLiveTests/MockData/example-package-c.json
@@ -7,7 +7,7 @@
   "name" : "ExamplePackageC",
   "packageKind" : {
     "root" : [
-      "/Users/simon/Developer/Example/ExamplePackageC"
+      "/Users/simon/Developer/Example/PackageC"
     ]
   },
   "pkgConfig" : null,

--- a/Tests/PackageSwiftFileParserLiveTests/PackageSwiftFileParserLiveTests.swift
+++ b/Tests/PackageSwiftFileParserLiveTests/PackageSwiftFileParserLiveTests.swift
@@ -8,7 +8,7 @@ final class PackageSwiftFileParserLiveTests: XCTestCase {
         let cache = PackageSwiftFileParserCacheMock()
         let dumpPackageService = DumpPackageServiceMock()
         let parser = PackageSwiftFileParserLive(cache: cache, dumpPackageService: dumpPackageService)
-        let packageSwiftFile = try parser.parseFile(at: URL.Mock.examplePackageA)
+        let packageSwiftFile = try parser.parseFile(at: URL.Mock.Example.packageA)
         XCTAssertEqual(packageSwiftFile.name, "ExamplePackageA")
     }
 
@@ -16,7 +16,7 @@ final class PackageSwiftFileParserLiveTests: XCTestCase {
         let cache = PackageSwiftFileParserCacheMock()
         let dumpPackageService = DumpPackageServiceMock()
         let parser = PackageSwiftFileParserLive(cache: cache, dumpPackageService: dumpPackageService)
-        let packageSwiftFile = try parser.parseFile(at: URL.Mock.examplePackageA)
+        let packageSwiftFile = try parser.parseFile(at: URL.Mock.Example.packageA)
         XCTAssertEqual(packageSwiftFile.products, [
             PackageSwiftFile.Product(name: "ExampleLibraryA", targets: ["ExampleLibraryA"])
         ])
@@ -26,7 +26,7 @@ final class PackageSwiftFileParserLiveTests: XCTestCase {
         let cache = PackageSwiftFileParserCacheMock()
         let dumpPackageService = DumpPackageServiceMock()
         let parser = PackageSwiftFileParserLive(cache: cache, dumpPackageService: dumpPackageService)
-        let packageSwiftFile = try parser.parseFile(at: URL.Mock.examplePackageA)
+        let packageSwiftFile = try parser.parseFile(at: URL.Mock.Example.packageA)
         XCTAssertEqual(packageSwiftFile.targets, [
             PackageSwiftFile.Target(name: "ExampleLibraryA")
         ])
@@ -36,11 +36,11 @@ final class PackageSwiftFileParserLiveTests: XCTestCase {
         let cache = PackageSwiftFileParserCacheMock()
         let dumpPackageService = DumpPackageServiceMock()
         let parser = PackageSwiftFileParserLive(cache: cache, dumpPackageService: dumpPackageService)
-        let swiftPackageFile = try parser.parseFile(at: URL.Mock.examplePackageB)
+        let swiftPackageFile = try parser.parseFile(at: URL.Mock.Example.packageB)
         XCTAssertEqual(swiftPackageFile.dependencies, [
             .fileSystem(
                 identity: "examplepackagec",
-                path: "/Users/simon/Developer/Example/ExamplePackageC",
+                path: "/Users/simon/Developer/Example/PackageC",
                 packageSwiftFile: PackageSwiftFile(
                     name: "ExamplePackageC",
                     products: [
@@ -66,13 +66,13 @@ final class PackageSwiftFileParserLiveTests: XCTestCase {
         XCTAssertEqual(parsedPackageSwiftFile, cachedPackageSwiftFile)
     }
 
-    func testParsesByNameDependencyWithPlatformNames() throws {
+    func testParsesDependencySyntaxByNameDependencyWithPlatformNames() throws {
         let cache = PackageSwiftFileParserCacheMock()
         let dumpPackageService = DumpPackageServiceMock()
         let parser = PackageSwiftFileParserLive(cache: cache, dumpPackageService: dumpPackageService)
-        let packageSwiftFile = try parser.parseFile(at: URL.Mock.examplePackageD)
+        let packageSwiftFile = try parser.parseFile(at: URL.Mock.DependencySyntax.byNameWithPlatformNames)
         let expectedPackageSwiftFile = PackageSwiftFile(
-            name: "ExamplePackageD",
+            name: "DependencySyntaxByNameWithPlatformNames",
             products: [
                 PackageSwiftFile.Product(name: "ExampleLibraryD", targets: ["ExampleLibraryD"])
             ],
@@ -84,7 +84,40 @@ final class PackageSwiftFileParserLiveTests: XCTestCase {
             dependencies: [
                 .fileSystem(
                     identity: "examplepackagec",
-                    path: "/Users/simon/Developer/Example/ExamplePackageC",
+                    path: "/Users/simon/Developer/Example/PackageC",
+                    packageSwiftFile: PackageSwiftFile(
+                        name: "ExamplePackageC",
+                        products: [
+                            .init(name: "ExampleLibraryC", targets: ["ExampleLibraryC"])
+                        ],
+                        targets: [
+                            .init(name: "ExampleLibraryC")
+                        ]
+                    )
+                )
+            ])
+        XCTAssertEqual(packageSwiftFile, expectedPackageSwiftFile)
+    }
+
+    func testParsesDependencySyntaxTarget() throws {
+        let cache = PackageSwiftFileParserCacheMock()
+        let dumpPackageService = DumpPackageServiceMock()
+        let parser = PackageSwiftFileParserLive(cache: cache, dumpPackageService: dumpPackageService)
+        let packageSwiftFile = try parser.parseFile(at: URL.Mock.DependencySyntax.target)
+        let expectedPackageSwiftFile = PackageSwiftFile(
+            name: "DependencySyntaxTarget",
+            products: [
+                PackageSwiftFile.Product(name: "ExampleLibraryD", targets: ["ExampleLibraryD"])
+            ],
+            targets: [
+                PackageSwiftFile.Target(name: "ExampleLibraryD", dependencies: [
+                    .name("ExampleLibraryC")
+                ])
+            ],
+            dependencies: [
+                .fileSystem(
+                    identity: "examplepackagec",
+                    path: "/Users/simon/Developer/Example/PackageC",
                     packageSwiftFile: PackageSwiftFile(
                         name: "ExamplePackageC",
                         products: [


### PR DESCRIPTION
This PR fixes #12 