### PR TITLE
Preliminary support for target dependency condition

### DIFF
--- a/Sources/Library/Parsing/PackageSwiftFileParserLive/Internal/IntermediatePackageSwiftFile+Target+Dependency.swift
+++ b/Sources/Library/Parsing/PackageSwiftFileParserLive/Internal/IntermediatePackageSwiftFile+Target+Dependency.swift
@@ -96,12 +96,15 @@ extension IntermediatePackageSwiftFile.Target.Dependency {
 
     private enum ProductComponent: Decodable {
         case string(String)
+        case condition(Condition)
         case null
 
         init(from decoder: Decoder) throws {
             let container = try decoder.singleValueContainer()
             if let str = try? container.decode(String.self) {
                 self = .string(str)
+            } else if let condition = try? container.decode(Condition.self) {
+                self = .condition(condition)
             } else if container.decodeNil() {
                 self = .null
             } else {
@@ -109,5 +112,11 @@ extension IntermediatePackageSwiftFile.Target.Dependency {
                 throw DecodingError.dataCorrupted(.init(codingPath: container.codingPath, debugDescription: debugDescription))
             }
         }
+    }
+}
+
+extension IntermediatePackageSwiftFile.Target.Dependency {
+    struct Condition: Decodable {
+        let platformNames: [String]
     }
 }

--- a/Tests/PackageSwiftFileParserLiveTests/MockData/example-package-b.json
+++ b/Tests/PackageSwiftFileParserLiveTests/MockData/example-package-b.json
@@ -83,7 +83,11 @@
             "KeyboardToolbar",
             "KeyboardToolbar",
             null,
-            null
+            {
+              "platformNames" : [
+                "ios"
+              ]
+            }
           ]
         }
       ],


### PR DESCRIPTION
Hey, I've made some preliminary changes to address issue #22. Although I'm uncertain if this is the optimal approach, and whether parsing the actual condition is even necessary. I noticed that `.target` dependency conditions are not parsed either. Furthermore, this change doesn't impact visualisation. I haven't included any tests yet, but I'm open to iterating on this 🙂

Based on this example `Package.swift`

```swift
// swift-tools-version: 5.8
import PackageDescription

let package = Package(
    name: "My Package",
    platforms: [
        .iOS(.v16)
    ],
    dependencies: [
        .package(url: "https://hello.world/package", from: "0.0.0")
    ],
    targets: [
        .target(
            name: "MyTarget",
            dependencies: [
                .product(
                    name: "Package",
                    package: "package",
                    condition: .when(platforms: [.iOS])
                ),
                .target(
                    name: "MyLibraryTarget", 
                    condition: .when(platforms: [.iOS])
                )
            ]
        )
    ]
)
```

I looked at the `swift package dump-package` output:

```json
...
"dependencies" : [
  {
    "product" : [
      "Package",
      "package",
      null,
      {
        "platformNames" : [
          "ios"
        ]
      }
    ]
  },
  {
    "target" : [
      "MyLibraryTarget",
      {
        "platformNames" : [
          "ios"
        ]
      }
    ]
  }
],
...
```